### PR TITLE
Fix: 태그 이름 저장 수정

### DIFF
--- a/like-knu-api/src/main/java/com/woopaca/likeknu/controller/dto/announcement/AnnouncementListResponse.java
+++ b/like-knu-api/src/main/java/com/woopaca/likeknu/controller/dto/announcement/AnnouncementListResponse.java
@@ -2,7 +2,6 @@ package com.woopaca.likeknu.controller.dto.announcement;
 
 import com.woopaca.likeknu.entity.Announcement;
 import lombok.Builder;
-
 import java.time.format.DateTimeFormatter;
 import java.util.Set;
 

--- a/like-knu-job/src/main/java/com/woopaca/likeknu/job/announcement/AnnouncementModifier.java
+++ b/like-knu-job/src/main/java/com/woopaca/likeknu/job/announcement/AnnouncementModifier.java
@@ -14,7 +14,7 @@ public class AnnouncementModifier {
 
     public AnnouncementModifier(AnnouncementRepository announcementRepository) {
         this.announcementRepository = announcementRepository;
-        this.announcementTagAbstracter = announcementMessage -> Tag.of(announcementMessage.getCategory().name());
+        this.announcementTagAbstracter = announcementMessage -> Tag.of(announcementMessage.getCategory().getCategoryName());
     }
 
     public void appendAnnouncement(AnnouncementMessage announcementMessage) {

--- a/like-knu-job/src/main/java/com/woopaca/likeknu/job/announcement/AnnouncementModifier.java
+++ b/like-knu-job/src/main/java/com/woopaca/likeknu/job/announcement/AnnouncementModifier.java
@@ -14,7 +14,7 @@ public class AnnouncementModifier {
 
     public AnnouncementModifier(AnnouncementRepository announcementRepository) {
         this.announcementRepository = announcementRepository;
-        this.announcementTagAbstracter = announcementMessage -> Tag.STUDENT_NEWS;
+        this.announcementTagAbstracter = announcementMessage -> Tag.of(announcementMessage.getCategory().name());
     }
 
     public void appendAnnouncement(AnnouncementMessage announcementMessage) {


### PR DESCRIPTION
## 📌 간단 설명

- 공지사항 확인 시 태그가 전부 '학생소식'으로 나오는 버그 수정


